### PR TITLE
Add Support for JaCoCo and dorny/test-reporter for Code Coverage

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,3 +53,11 @@ jobs:
       with:
         name: jacoco-report
         path: target/site/jacoco/
+
+    - name: Comment coverage report
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: JaCoCo coverage
+        path: target/site/jacoco/jacoco.xml
+        reporter: jacoco

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,10 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Install dependencies and run tests
-      run: mvn clean install
+      run: mvn clean verify
+
+    - name: Generate JaCoCo report
+      run: mvn jacoco:report
 
     - name: Archive test results
       if: always()
@@ -44,3 +47,9 @@ jobs:
       with:
         name: junit-test-results
         path: target/surefire-reports/*.xml
+
+    - name: Upload JaCoCo report
+      uses: actions/upload-artifact@v3
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
                     <target>21</target>
                 </configuration>
             </plugin>
+                 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -61,6 +62,47 @@
                         <include>**/*Test.java</include>
                     </includes>
                 </configuration>
+            </plugin>
+                 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/mycompany/bookstore/gui/BookStoreGUI.java
+++ b/src/main/java/com/mycompany/bookstore/gui/BookStoreGUI.java
@@ -35,7 +35,7 @@ public class BookStoreGUI extends javax.swing.JFrame {
     private final BookStore store;
 
     /**
-     *
+     * Painel central do usuário.
      */
     private JPanel userPanel;
 


### PR DESCRIPTION
This pull request adds support for generating and visualizing code coverage reports using JaCoCo and dorny/test-reporter. The main changes include:

- **Configuration of JaCoCo in Maven**:
  - Added the JaCoCo plugin to `pom.xml` to instrument class files and generate coverage reports.
  - Configured to generate coverage reports during the `verify` phase.

- **Update to GitHub Actions Workflow**:
  - Added steps in `.github/workflows/maven.yml` to generate the JaCoCo report and upload it as an artifact.
  - Integrated `dorny/test-reporter` to automatically comment code coverage results on pull requests.

### Details of Changes

1. **`pom.xml` File**:
    - Added the `jacoco-maven-plugin` to generate coverage reports.

2. **`.github/workflows/maven.yml` File**:
    - Modified the workflow to include steps for generating and uploading JaCoCo reports.
    - Included `dorny/test-reporter` to comment coverage results on pull requests.
