### PR TITLE
Add Support for JaCoCo for Code Coverage

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,4 +60,4 @@ jobs:
       with:
         name: JaCoCo coverage
         path: jacoco.xml
-        reporter: jacoco1
+        reporter: jacoco

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,3 +53,11 @@ jobs:
       with:
         name: jacoco-report
         path: target/site/jacoco/
+
+    - name: Comment coverage report
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: JaCoCo coverage
+        path: target/site/jacoco/jacoco.xml
+        reporter: jacoco

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '21'
+        java-version: '17'
 
     - name: Cache Maven packages
       uses: actions/cache@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,5 +59,5 @@ jobs:
       if: always()
       with:
         name: JaCoCo coverage
-        path: target/site/jacoco/jacoco.xml
-        reporter: jacoco
+        path: jacoco.xml
+        reporter: jacoco1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -58,6 +58,6 @@ jobs:
       uses: dorny/test-reporter@v1
       if: always()
       with:
-        name: JaCoCo coverage
+        name: jacoco
         path: jacoco.xml
-        reporter: jacoco-report
+        reporter: jacoco

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,10 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Install dependencies and run tests
-      run: mvn clean install
+      run: mvn clean verify
+
+    - name: Generate JaCoCo report
+      run: mvn jacoco:report
 
     - name: Archive test results
       if: always()
@@ -44,3 +47,9 @@ jobs:
       with:
         name: junit-test-results
         path: target/surefire-reports/*.xml
+
+    - name: Upload JaCoCo report
+      uses: actions/upload-artifact@v3
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,4 +60,4 @@ jobs:
       with:
         name: JaCoCo coverage
         path: jacoco.xml
-        reporter: jacoco
+        reporter: jacoco-report

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,11 +53,3 @@ jobs:
       with:
         name: jacoco-report
         path: target/site/jacoco/
-
-    - name: Comment coverage report
-      uses: dorny/test-reporter@v1
-      if: always()
-      with:
-        name: jacoco
-        path: jacoco.xml
-        reporter: jacoco

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <exec.mainClass>com.mycompany.bookstore.BookStore</exec.mainClass>
     </properties>
     
@@ -48,8 +48,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
                 <version>3.0.0-M5</version>
                 <configuration>
                     <includes>
-                    v<include>**/*Test.java</include>
+                        <include>**/*Test.java</include>
                     </includes>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -52,43 +52,20 @@
                     <target>21</target>
                 </configuration>
             </plugin>
-                 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
                     <includes>
-                        <include>**/*Test.java</include>
+                    v<include>**/*Test.java</include>
                     </includes>
                 </configuration>
             </plugin>
-                 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
                     <target>21</target>
                 </configuration>
             </plugin>
+                 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -61,6 +62,47 @@
                         <include>**/*Test.java</include>
                     </includes>
                 </configuration>
+            </plugin>
+                 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/mycompany/bookstore/gui/BookStoreGUI.java
+++ b/src/main/java/com/mycompany/bookstore/gui/BookStoreGUI.java
@@ -35,7 +35,7 @@ public class BookStoreGUI extends javax.swing.JFrame {
     private final BookStore store;
 
     /**
-     *
+     * Painel central do usuário.
      */
     private JPanel userPanel;
 


### PR DESCRIPTION
This pull request adds support for generating and visualizing code coverage reports using JaCoCo. The main changes include:

- **Configuration of JaCoCo in Maven**:
  - Added the JaCoCo plugin to `pom.xml` to instrument class files and generate coverage reports.
  - Configured to generate coverage reports during the `verify` phase.

- **Update to GitHub Actions Workflow**:
  - Added steps in `.github/workflows/maven.yml` to generate the JaCoCo report and upload it as an artifact.

### Details of Changes

1. **`pom.xml` File**:
    - Added the `jacoco-maven-plugin` to generate coverage reports.

2. **`.github/workflows/maven.yml` File**:
    - Modified the workflow to include steps for generating and uploading JaCoCo reports.